### PR TITLE
Fix: Serve media files in development and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ diffs
 .env
 backend/src/db.sqlite3
 __pycache__/
+/backend/media

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -21,6 +21,9 @@ load_dotenv()
 BASE_DIR = Path(__file__).resolve().parent.parent
 
 
+MEDIA_URL = '/media/'
+MEDIA_ROOT = BASE_DIR.parent / 'media'
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 

--- a/backend/src/config/urls.py
+++ b/backend/src/config/urls.py
@@ -16,7 +16,12 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import path
+from django.conf import settings
+from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
This commit configures Django to serve media files during development by updating settings.py and urls.py. It also updates .gitignore to exclude the /backend/media directory, preventing media files from being committed to the repository.