### PR TITLE
Fix: Serve media files in development and update .gitignore

### DIFF
--- a/backend/src/config/urls.py
+++ b/backend/src/config/urls.py
@@ -15,7 +15,11 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
+<<<<<<< HEAD
 from django.urls import path, include
+=======
+from django.urls import path
+>>>>>>> 89e75b3 (Fix: Serve media files in development and update .gitignore)
 from django.conf import settings
 from django.conf.urls.static import static
 


### PR DESCRIPTION
This commit configures Django to serve media files during development by updating settings.py and urls.py. It also updates .gitignore to exclude the /backend/media directory, preventing media files from being committed to the repository.